### PR TITLE
Create a tool to generates the `alloc` constant from a genesis config file.

### DIFF
--- a/core/mkalloc_tendermint.go
+++ b/core/mkalloc_tendermint.go
@@ -1,0 +1,58 @@
+// +build none
+
+/*
+
+   The mkalloc tool creates the genesis allocation constants in genesis_alloc.go for tendermint genesis configuration
+   It outputs a const declaration that contains (address, balance and precompiled Staking Smart Contract).
+
+       go run mkalloc_tendermint.go genesis.json
+
+*/
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	// AllocPath returns the path of alloc data in the genesis config file
+	AllocPath = "alloc"
+)
+
+// readJSONData reads data of alloc config
+func readJSONData(genesisPath string) (string, error) {
+	jsonData, err := ioutil.ReadFile(genesisPath)
+	if err != nil {
+		return "", err
+	}
+	data := gjson.Get(string(jsonData), AllocPath)
+	if !data.Exists() {
+		return "", errors.New("data at `alloc` not existed")
+	}
+
+	input := strings.Replace(data.Raw, "\n", "", -1)
+	input = strings.Replace(input, " ", "", -1)
+	input = strconv.Quote(input)
+	return input, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: mkalloc genesis.json")
+		os.Exit(1)
+	}
+
+	content, err := readJSONData(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("const allocData =", content)
+}

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.0
+	github.com/tidwall/gjson v1.6.0 // indirect
 	github.com/tyler-smith/go-bip39 v1.0.2
 	github.com/urfave/cli v1.22.1
 	github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,12 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=
+github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
+github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tyler-smith/go-bip39 v1.0.2 h1:+t3w+KwLXO6154GNJY+qUtIxLTmFjfUmpguQT1OlOT8=
 github.com/tyler-smith/go-bip39 v1.0.2/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=


### PR DESCRIPTION
With PR #73 we easily ran a publictestnet node, I create this PR to allow a developer to generates alloc const in the core/genesis_alloc.go.