### PR TITLE
Update Explorer deployment script

### DIFF
--- a/deploy/testnet/deploy_explorer.sh
+++ b/deploy/testnet/deploy_explorer.sh
@@ -4,33 +4,55 @@ version=
 until [[ $version ]]; do read -rp "- Tag Version/Branch Name you want to deploy: " version; done
 env=
 until [[ $env ]]; do read -rp "- Environment of Image: " env; done
+rpcAddr=
+until [[ $rpcAddr ]]; do read -rp "- Input RPC Address to connect: " rpcAddr; done
+rpcPort=
+until [[ $rpcPort ]]; do read -rp "- Input RPC Port to connect: " rpcPort; done
 
+# Replace / with -
+newVersion=${version//\//-}
+
+BASEDIR=$(dirname "$0")
 EXPLORER_REPOSITORY="kybernetwork/evrynet-explorer"
 EXPLORER_TAG_ENV="$EXPLORER_REPOSITORY:$version-$env"
 
-# Check status of explorer image
-if [[ "$(sudo docker images -q "$EXPLORER_TAG_ENV" 2>/dev/null)" == "" ]]; then
-  pullExplorerImage=
-  until [[ $pullExplorerImage ]]; do read -rp "** Image $EXPLORER_TAG_ENV doesn't exist on your local! Do you want to pull this image? " pullExplorerImage; done
+rm -rf "$BASEDIR"/explorer/web
+# Already existed image
+if [[ "$(sudo docker images -q "$EXPLORER_TAG_ENV" 2>/dev/null)" != "" ]]; then
+  echo "=> Image $EXPLORER_TAG_ENV already existed!"
+  rebuild=
+  until [[ $rebuild ]]; do read -rp "- Do you want to re-build Explorer Image? (y/n) " rebuild; done
 
-  if [[ "$pullExplorerImage" == "y" ]]; then
-    yes | sudo docker pull "$EXPLORER_TAG_ENV"
+  if [[ "$rebuild" == "y" ]]; then
+    echo "--- Cloning explorer from master branch ..."
+    git clone -b "$version" git@github.com:Evrynetlabs/explorer.git "$BASEDIR"/explorer/web
 
-    # Check status of explorer image
-    if [[ "$(sudo docker images -q "$EXPLORER_TAG_ENV" 2>/dev/null)" == "" ]]; then
-      echo "=> Can not pull Image $EXPLORER_TAG_ENV . Make sure this image has existed on your hub!"
-      exit 1
-    fi
-  else
-    echo "=> You must build explorer image on you local. Read README.md to know the way to build!"
-    exit 1
+    echo "--- Removing docker container & image for $EXPLORER_TAG_ENV ..."
+    sudo docker rmi -f $EXPLORER_TAG_ENV
+    sudo docker rm -f gev-explorer
+
+    echo "--- Building explorer image $EXPLORER_TAG_ENV "
+    yes | sudo docker build -f "$BASEDIR"/explorer/Dockerfile -t "$EXPLORER_TAG_ENV" "$BASEDIR"/explorer
   fi
+else
+  echo "--- Cloning explorer from master branch ..."
+  git clone -b "$version" git@github.com:Evrynetlabs/explorer.git "$BASEDIR"/explorer/web
+
+  echo "--- Removing docker container & image for $EXPLORER_TAG_ENV ..."
+  sudo docker rmi -f $EXPLORER_TAG_ENV
+  sudo docker rm -f gev-explorer
+
+  echo "--- Building explorer image $EXPLORER_TAG_ENV "
+  yes | sudo docker build -f "$BASEDIR"/explorer/Dockerfile -t "$EXPLORER_TAG_ENV" "$BASEDIR"/explorer
+
 fi
+rm -rf "$BASEDIR"/explorer/web
 
 yes | sudo docker rm -f gev-explorer
 
 echo "--- Starting explorer on image $EXPLORER_TAG_ENV..."
 yes | sudo docker run --name gev-explorer -d \
   --publish 8080:8080 \
-  -e GETH_RPCPORT=22001 \
+  -e GEV_RPCPORT=$rpcPort \
+  -e GEV_HOSTNAME=$rpcAddr \
   "$EXPLORER_TAG_ENV"

--- a/deploy/testnet/explorer/Dockerfile
+++ b/deploy/testnet/explorer/Dockerfile
@@ -5,8 +5,7 @@ COPY ./web/ ./
 COPY ./env_setup.sh .
 RUN chmod +x env_setup.sh
 
-RUN ./env_setup.sh
 RUN npm install
-CMD npm start
+CMD ["/bin/bash", "./env_setup.sh"]
 
 EXPOSE 8080

--- a/deploy/testnet/explorer/env_setup.sh
+++ b/deploy/testnet/explorer/env_setup.sh
@@ -4,10 +4,16 @@ echo "----- Setup environment variables -----"
 ls -la
 
 # shellcheck disable=SC2039
-if [[ ! $GETH_RPCPORT ]]; then
-  GETH_RPCPORT="22001"
+if [[ ! $GEV_RPCPORT ]]; then
+  GEV_RPCPORT="22001"
 fi
 
 sed -i -e \
-  's/ENV_GEV_RPCPORT/'"$GETH_RPCPORT"'/g' \
+  's/ENV_GEV_RPCPORT/"'$GEV_RPCPORT'"/g' \
   ./app/app.js
+
+sed -i -e \
+  's/ENV_GEV_HOSTNAME/"'$GEV_HOSTNAME'"/g' \
+  ./app/app.js
+
+npm start


### PR DESCRIPTION
The Explorer project was added new param, so we need to update deployment script.

In this PR, I do:
- In `build_images_for_bootnode_node_explorer.sh` file, I updated some paths to `"$BASEDIR"` to make it's more flexible. 
I also make a folder `bin` in `nodes` and `bootnode` to avoid an error when `docker cp` run.
- In `deploy_explorer.sh` file, I added new scripts which allowing building the explorer project.
Allowing input RPC Address and RPC Port to deploy.
- In `env_setup.sh`, I handled new input `ENV_GEV_HOSTNAME `