### PR TITLE
unmarhsal to nil owner/provider

### DIFF
--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -116,8 +116,11 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 	t.PV = (*big.Int)(dec.PV)
 	t.PR = (*big.Int)(dec.PR)
 	t.PS = (*big.Int)(dec.PS)
-
-	t.Provider = dec.Provider
-	t.Owner = dec.Owner
+	if dec.Provider!=nil && dec.Provider.String()!=(common.Address{}).String() {
+			t.Provider = dec.Provider
+	}
+	if dec.Owner!=nil && dec.Provider.String()!=(common.Address{}.String()) {
+		t.Owner = dec.Owner
+	}
 	return nil
 }

--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -22,14 +22,14 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 		Recipient    *common.Address `json:"to"       rlp:"nil"`
 		Amount       *hexutil.Big    `json:"value"    gencodec:"required"`
 		Payload      hexutil.Bytes   `json:"input"    gencodec:"required"`
+		Owner        *common.Address `json:"owner" rlp:"nil"`
+		Provider     *common.Address `json:"provider" rlp:"nil"`
 		V            *hexutil.Big    `json:"v" gencodec:"required"`
 		R            *hexutil.Big    `json:"r" gencodec:"required"`
 		S            *hexutil.Big    `json:"s" gencodec:"required"`
-		PV           *hexutil.Big    `json:"pv"`
-		PR           *hexutil.Big    `json:"pr"`
-		PS           *hexutil.Big    `json:"ps"`
-		Owner        *common.Address `json:"owner" rlp:"nil"`
-		Provider     *common.Address `json:"provider" rlp:"nil"`
+		PV           *hexutil.Big    `json:"pv"       rlp:"nil"`
+		PR           *hexutil.Big    `json:"pr"       rlp:"nil"`
+		PS           *hexutil.Big    `json:"ps"       rlp:"nil"`
 		Hash         *common.Hash    `json:"hash" rlp:"-"`
 	}
 	var enc txdata
@@ -39,6 +39,8 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 	enc.Recipient = t.Recipient
 	enc.Amount = (*hexutil.Big)(t.Amount)
 	enc.Payload = t.Payload
+	enc.Owner = t.Owner
+	enc.Provider = t.Provider
 	enc.V = (*hexutil.Big)(t.V)
 	enc.R = (*hexutil.Big)(t.R)
 	enc.S = (*hexutil.Big)(t.S)
@@ -46,8 +48,6 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 	enc.PR = (*hexutil.Big)(t.PR)
 	enc.PS = (*hexutil.Big)(t.PS)
 	enc.Hash = t.Hash
-	enc.Provider = t.Provider
-	enc.Owner = t.Owner
 	return json.Marshal(&enc)
 }
 
@@ -60,14 +60,14 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		Recipient    *common.Address `json:"to"       rlp:"nil"`
 		Amount       *hexutil.Big    `json:"value"    gencodec:"required"`
 		Payload      *hexutil.Bytes  `json:"input"    gencodec:"required"`
+		Owner        *common.Address `json:"owner" rlp:"nil"`
+		Provider     *common.Address `json:"provider" rlp:"nil"`
 		V            *hexutil.Big    `json:"v" gencodec:"required"`
 		R            *hexutil.Big    `json:"r" gencodec:"required"`
 		S            *hexutil.Big    `json:"s" gencodec:"required"`
-		PV           *hexutil.Big    `json:"pv"`
-		PR           *hexutil.Big    `json:"pr"`
-		PS           *hexutil.Big    `json:"ps"`
-		Owner        *common.Address `json:"owner" rlp:"nil"`
-		Provider     *common.Address `json:"provider" rlp:"nil"`
+		PV           *hexutil.Big    `json:"pv"       rlp:"nil"`
+		PR           *hexutil.Big    `json:"pr"       rlp:"nil"`
+		PS           *hexutil.Big    `json:"ps"       rlp:"nil"`
 		Hash         *common.Hash    `json:"hash" rlp:"-"`
 	}
 	var dec txdata
@@ -97,6 +97,12 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'input' for txdata")
 	}
 	t.Payload = *dec.Payload
+	if dec.Owner != nil {
+		t.Owner = dec.Owner
+	}
+	if dec.Provider != nil {
+		t.Provider = dec.Provider
+	}
 	if dec.V == nil {
 		return errors.New("missing required field 'v' for txdata")
 	}
@@ -109,18 +115,17 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 's' for txdata")
 	}
 	t.S = (*big.Int)(dec.S)
+	if dec.PV != nil {
+		t.PV = (*big.Int)(dec.PV)
+	}
+	if dec.PR != nil {
+		t.PR = (*big.Int)(dec.PR)
+	}
+	if dec.PS != nil {
+		t.PS = (*big.Int)(dec.PS)
+	}
 	if dec.Hash != nil {
 		t.Hash = dec.Hash
-	}
-
-	t.PV = (*big.Int)(dec.PV)
-	t.PR = (*big.Int)(dec.PR)
-	t.PS = (*big.Int)(dec.PS)
-	if dec.Provider!=nil && dec.Provider.String()!=(common.Address{}).String() {
-			t.Provider = dec.Provider
-	}
-	if dec.Owner!=nil && dec.Provider.String()!=(common.Address{}.String()) {
-		t.Owner = dec.Owner
 	}
 	return nil
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -119,6 +119,9 @@ type txdataMarshaling struct {
 	V            *hexutil.Big
 	R            *hexutil.Big
 	S            *hexutil.Big
+	PV           *hexutil.Big
+	PR           *hexutil.Big
+	PS           *hexutil.Big
 }
 
 func NewTransaction(nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) *Transaction {

--- a/internal/evrapi/api.go
+++ b/internal/evrapi/api.go
@@ -1130,8 +1130,8 @@ type RPCTransaction struct {
 	TransactionIndex hexutil.Uint    `json:"transactionIndex"`
 	Value            *hexutil.Big    `json:"value"`
 
-	Owner    common.Address `json:"owner"`
-	Provider common.Address `json:"provider"`
+	Owner    *common.Address `json:"owner"`
+	Provider *common.Address `json:"provider"`
 
 	V *hexutil.Big `json:"v"`
 	R *hexutil.Big `json:"r"`
@@ -1167,19 +1167,11 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		R:        (*hexutil.Big)(r),
 		S:        (*hexutil.Big)(s),
 
-		PV: (*hexutil.Big)(PV),
-		PR: (*hexutil.Big)(PR),
-		PS: (*hexutil.Big)(PS),
-	}
-
-	ownerAddr := tx.Owner()
-	if ownerAddr != nil {
-		result.Owner = *ownerAddr
-	}
-
-	providerAddr := tx.Provider()
-	if providerAddr != nil {
-		result.Provider = *providerAddr
+		PV:       (*hexutil.Big)(PV),
+		PR:       (*hexutil.Big)(PR),
+		PS:       (*hexutil.Big)(PS),
+		Owner:    tx.Owner(),
+		Provider: tx.Provider(),
 	}
 
 	if blockHash != (common.Hash{}) {


### PR DESCRIPTION
This Pr fix the issue: when get transaction for block and try to get the hash. The hash deprived from transaction and the hash used to get transaction are miss-match.
```
package main

import (
	"context"
	"fmt"
	"github.com/Evrynetlabs/evrynet-node/common"
	"github.com/Evrynetlabs/evrynet-node/evrclient"
	"log"
)

func main() {
  addr := "http://localhost:22001"
  client, err := evrclient.Dial(addr)
  if err != nil {
    log.Fatal(fmt.Sprintf("failed to dial addr: %v", addr))
  }
   tx, _, _ := client.TransactionByHash(context.Background(),common.HexToHash("0x4f7dc293e39e04e444e863b5ac77a5128c20d35846043302850661b63a3a7b48" +
   	""))
  if tx!= nil {
  	  log.Printf("tx by hash 's hash %s", tx.Hash().Hex())
  }
}
```

The reason is when get tx from rpc, the field owner and provider is '0x0' instead of null
